### PR TITLE
improve dragging experience

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,6 +1,10 @@
 <template>
   <require from="./app.css"></require>
-  <div class="absolute inset-0" mouseup.delegate="beaker.onMouseUp($event)">
+  <div
+    class="absolute inset-0"
+    mousemove.delegate="beaker.onMouseMove($event)"
+    mouseup.delegate="beaker.onMouseUp($event)"
+  >
     <div
       ref="element.node"
       repeat.for="element of beaker.elements"

--- a/src/components/beaker/index.js
+++ b/src/components/beaker/index.js
@@ -14,6 +14,12 @@ class Beaker {
     window.cancelAnimationFrame(this.raf);
   }
 
+  onMouseMove(event) {
+    const element = this._getDraggedElement();
+
+    if (element) element.onMouseMove(event);
+  }
+
   onMouseUp(event) {
     this._checkForCollision(event);
     this._broadcast('onMouseUp');
@@ -25,7 +31,7 @@ class Beaker {
   };
 
   _checkForCollision(event) {
-    let draggedElement = this.elements.find(element => element.isMouseDown);
+    let draggedElement = this._getDraggedElement();
     if (!draggedElement) {
       this._spawnNewElement(event);
       return;
@@ -43,6 +49,10 @@ class Beaker {
 
     newElement.setPosition(event.pageX, event.pageY);
     this.elements.push(newElement);
+  }
+
+  _getDraggedElement() {
+    return this.elements.find(element => element.isMouseDown);
   }
 
   _getCollidingElement(draggedElement) {


### PR DESCRIPTION
when the mouse move too fast, the mousemove event will be triggered on beaker instead of on the dragged element